### PR TITLE
Use references to DynamoDB and SNS to avoid manually setting account ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,13 +116,6 @@ environment:
     slackWebhookUrl: UPDATE_YOUR_SLACK_WEBHOOK HERE # https://slack.com/intl/en-ca/help/articles/115005265063-Incoming-Webhooks-for-Slack
 ```
 
-Enter your AWS account Id
-
-```yaml
-environment:    
-    awsAccountId: UPDATE_YOUR_AWS_ACCOUNT_ID_HERE
-```
-
 If you want to disable cloud metrics set `enableMetrics` to `false` in `serverless.yml`
 
 ```yaml

--- a/handler.js
+++ b/handler.js
@@ -12,10 +12,9 @@ let docClient = new AWS.DynamoDB.DocumentClient();
 // declare variables
 const ENDPOINT_TIMEOUT = 5000; // milliseconds
 const SLACK_WEBHOOK_URL = process.env.slackWebhookUrl;
-const AWS_REGION = process.env.AWS_REGION;
-const DYNAMO_TABLE = "lambda-monitor-" + process.env.stage;
+const DYNAMO_TABLE = process.env.dynamoTable;
 const ENABLE_METRICS = process.env.enableMetrics || true;
-const SNS_TOPIC_ARN = "arn:aws:sns:" + AWS_REGION + ":" + process.env.awsAccountId + ":" + "lambda-monitor-" + process.env.stage;
+const SNS_TOPIC_ARN = process.env.snsTopicArn;
 let cloudWatchOutput = {};
 
 // main function

--- a/serverless-example.yml
+++ b/serverless-example.yml
@@ -18,11 +18,15 @@ provider:
       Action:
         - dynamodb:GetItem
         - dynamodb:UpdateItem
-      Resource: arn:aws:dynamodb:${opt:region, self:provider.region}:*:table/lambda-monitor-${opt:stage}
+      Resource:
+        Fn::GetAtt:
+          - MonitorDynamoDbTable
+          - Arn
     - Effect: Allow
       Action:
         - SNS:Publish
-      Resource: arn:aws:sns:${opt:region, self:provider.region}:*:lambda-monitor-${opt:stage}
+      Resource:
+        Ref: MonitorSnsTopic
 
 resources:
   Description: Check HTTP response code & latency for scheduled endpoints & send alerts to Slack
@@ -52,8 +56,11 @@ functions:
     environment:
       stage: ${opt:stage}
       slackWebhookUrl: UPDATE_YOUR_SLACK_WEBHOOK HERE # https://slack.com/intl/en-ca/help/articles/115005265063-Incoming-Webhooks-for-Slack
-      awsAccountId: UPDATE_YOUR_AWS_ACCOUNT_ID_HERE
       enableMetrics: true
+      snsTopicArn:
+        Ref: MonitorSnsTopic
+      dynamoTable:
+        Ref: MonitorDynamoDbTable
     description: "Perform an HTTP request to 'ping' a remote server to determine availability"
     memorySize: 128 # MB
     timeout: 30 # seconds


### PR DESCRIPTION
By using references to these created resources, we can avoid having to manually set the account ID in the Serverless configuration file.

This also makes it easier to change the name of these resources, because the handler JS doesn't need to be updated with the new names.